### PR TITLE
./users made powercord not import the users list

### DIFF
--- a/src/main/_powercord.scss
+++ b/src/main/_powercord.scss
@@ -37,4 +37,4 @@
     }
 }
 
-@import "./users";
+@import "./_users";


### PR DESCRIPTION
I realized that Powercord didn't load the _users.scss file so after swapping ./users to ./_users and restarting discord it started showing the badges.
![image](https://user-images.githubusercontent.com/8841466/115133942-430e6280-a00c-11eb-9579-40b5e5bc19b5.png)
